### PR TITLE
Update HAProxy to 1.9.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM haproxy:1.8.13
+
+# Install rsyslog
+RUN apt-get update && \
+  apt-get -y install rsyslog && \
+  rm -rf /var/lib/apt/lists/*
+
+ADD haproxy.conf /etc/rsyslog.d
+ADD rsyslog.conf /etc/rsyslog.conf
+COPY docker-entrypoint.sh /
+
+
+EXPOSE 80 443 1883 8883 1988
+
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM haproxy:1.8.13
+FROM haproxy:1.9.0
 
 # Install rsyslog
 RUN apt-get update && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,8 @@ ADD haproxy.conf /etc/rsyslog.d
 ADD rsyslog.conf /etc/rsyslog.conf
 COPY docker-entrypoint.sh /
 
+# Optional ENV var you could override:
+# HAPROXY_CFG_FILE setup the full path (in the container) where to load the HAproxy config
 
 EXPOSE 80 443 1883 8883 1988
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 Aerial
+Copyright (c) 2018-2019 Aerial
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
+
 # Optional ENV VAR:
 #  HAPROXY_CFG_FILE  the absolute path to the HAPRoxy.cfg file you want to use
 #    defaults to /usr/local/etc/haproxy/haproxy.cfg if unset
-PID_FILE="/var/run/haproxy.pid"
 
+PID_FILE="/var/run/haproxy.pid"
 
 # Make sure service is running
 service rsyslog start
@@ -14,18 +15,7 @@ touch /var/log/haproxy.log
 # Throw the log to output
 tail -f /var/log/haproxy.log &
 
-
-#function reload
-#{
-#  haproxy -f <config> -p <pidfile> -sf $(cat <pidfile>) &
-#  wait
-#}
-#
-#trap reload SIGHUP
-#trap "kill -TERM $(cat pidfile) || exit 1" SIGTERM SIGINT
-
 # Start haproxy
-#   -W  -- "master-worker mode" (similar to the old "haproxy-systemd-wrapper"; allows for reload via "SIGUSR2")
 exec haproxy -W \
   -f "${HAPROXY_CFG_FILE:-/usr/local/etc/haproxy/haproxy.cfg}" \
   -p $PID_FILE \

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Optional ENV VAR:
+#  HAPROXY_CFG_FILE  the absolute path to the HAPRoxy.cfg file you want to use
+#    defaults to /usr/local/etc/haproxy/haproxy.cfg if unset
+PID_FILE="/var/run/haproxy.pid"
+
+
+# Make sure service is running
+service rsyslog start
+
+# Touch the log file so we can tail on it
+touch /var/log/haproxy.log
+
+# Throw the log to output
+tail -f /var/log/haproxy.log &
+
+
+#function reload
+#{
+#  haproxy -f <config> -p <pidfile> -sf $(cat <pidfile>) &
+#  wait
+#}
+#
+#trap reload SIGHUP
+#trap "kill -TERM $(cat pidfile) || exit 1" SIGTERM SIGINT
+
+# Start haproxy
+#   -W  -- "master-worker mode" (similar to the old "haproxy-systemd-wrapper"; allows for reload via "SIGUSR2")
+exec haproxy -W \
+  -f "${HAPROXY_CFG_FILE:-/usr/local/etc/haproxy/haproxy.cfg}" \
+  -p $PID_FILE \
+  -sf $(cat $PID_FILE)

--- a/haproxy.conf
+++ b/haproxy.conf
@@ -1,0 +1,2 @@
+local2.*    /var/log/haproxy.log
+& ~

--- a/rsyslog.conf
+++ b/rsyslog.conf
@@ -1,0 +1,39 @@
+module(load="imuxsock") # provides support for local system logging
+module(load="imklog")   # provides kernel logging support
+
+module(load="imudp")
+input(type="imudp" port="514")
+
+$ActionFileDefaultTemplate RSYSLOG_TraditionalFileFormat
+
+$FileOwner root
+$FileGroup adm
+$FileCreateMode 0640
+$DirCreateMode 0755
+$Umask 0022
+
+$WorkDirectory /var/spool/rsyslog
+
+$IncludeConfig /etc/rsyslog.d/*.conf
+
+auth,authpriv.*			/var/log/auth.log
+*.*;auth,authpriv.none		-/var/log/syslog
+daemon.*			-/var/log/daemon.log
+kern.*				-/var/log/kern.log
+lpr.*				-/var/log/lpr.log
+mail.*				-/var/log/mail.log
+user.*				-/var/log/user.log
+
+mail.info			-/var/log/mail.info
+mail.warn			-/var/log/mail.warn
+mail.err			/var/log/mail.err
+
+*.=debug;\
+	auth,authpriv.none;\
+	news.none;mail.none	-/var/log/debug
+*.=info;*.=notice;*.=warn;\
+	auth,authpriv.none;\
+	cron,daemon.none;\
+	mail,news.none		-/var/log/messages
+
+*.emerg				:omusrmsg:*


### PR DESCRIPTION
This PR updates the HAProxy image to the current latest which is `1.9.0`. This PR also updates the LICENSE file by adding a date range due to the recent year change (from 2018 to 2019). 

**Note to reviewers** : The update will reside in the `1.9.0` branch, following the same structure as the previous version.  