### PR TITLE
1.9.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM haproxy:1.9.0
+FROM haproxy:1.9.5
 
 # Install rsyslog
 RUN apt-get update && \


### PR DESCRIPTION
This PR bumps HAProxy to 1.9.5.
The target branch will be updated to 1.9.5 once created.